### PR TITLE
Fix: config option name not printing as application

### DIFF
--- a/src/decorators/function.js
+++ b/src/decorators/function.js
@@ -35,13 +35,14 @@ export default class FunctionDecorator extends BaseFunctionDecorator {
             resultSanitizer,
             errorSanitizer,
             contextSanitizer,
-            timestamp
+            timestamp,
+            name
         } = this.config;
 
         const basicLogObject = {
+            application : name,
             service     : this.config.serviceName,
-            method      : methodName,
-            application : this.name
+            method      : methodName
         };
 
         const buildLogObject = (level, obj) => {
@@ -65,7 +66,7 @@ export default class FunctionDecorator extends BaseFunctionDecorator {
 
             if (isFunction(logger)) return logger(lev, dat);
             if (isFunction(logger[lev])) return logger[lev](dat);
-            throw new Error(`logger not supports ${lev} level`);
+            throw new Error(`logger does not support ${lev} level`); // Alternatively - logger level ${lev} not supported
         };
 
         const time = startBenchmark();

--- a/tests/package/configurations.test.js
+++ b/tests/package/configurations.test.js
@@ -131,7 +131,7 @@ test('Negative: broken logger', function () {
 
     assert.throws(() => {
         decorated(5, 9);
-    }, Error, 'logger not supports');
+    }, Error, 'logger does not support');
 });
 
 test('Positive: function logger', function () {


### PR DESCRIPTION
Fixed:
- config option 'name' not passing to logged data as 'application'
- Unsupported Logger error message grammer

**My apologies, the PR was posted before I had the chance to edit all the information**

Tests do not throw errors, except `npm run test:package` - Which I am not sure about, is it my global Node version crashing it?

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Changes:

1. Uses config `name` instead of `this.name` when passing logged data property 'application'
2. Changes unsupported logger error to `logger does not support ${lev} level`, also added alternative wording in comment
    - Edits tests/package/configurations - Unsupported logger error expected message accordingly

**Fixes** #129 
closes #129 


### NPM Tests:
<img width="2560" alt="Screen Shot 2024-03-02 at 19 24 59" src="https://github.com/pustovitDmytro/logger-decorator/assets/19843319/aa7c9d6a-a8cb-49b5-adae-9025493617c7">

<img width="756" alt="Screen Shot 2024-03-02 at 19 25 27" src="https://github.com/pustovitDmytro/logger-decorator/assets/19843319/3bd84287-10d8-464d-bbb5-f47e4c864fc1">

<img width="981" alt="Screen Shot 2024-03-02 at 19 25 45" src="https://github.com/pustovitDmytro/logger-decorator/assets/19843319/887918ca-df20-43c6-9014-f6e9fecf9e5c">

<img width="2560" alt="Screen Shot 2024-03-02 at 19 26 16" src="https://github.com/pustovitDmytro/logger-decorator/assets/19843319/d6b60935-f8e9-4557-a87b-39a88c36a144">

